### PR TITLE
Yazur interface bugfix

### DIFF
--- a/src/app/services/yazur.service.ts
+++ b/src/app/services/yazur.service.ts
@@ -60,7 +60,7 @@ export class Chip {
     const chipwait = this.localEnv.global[this.localEnv.chipwaitField].value;
     if (chipwait >= 0 && chipwait < 1){
       yazurInterpret( this );
-    } else {
+    } else if (chipwait >= 1){
       this.localEnv.global[this.localEnv.chipwaitField].value -= 1;
     }
 


### PR DESCRIPTION
- Don't decrement Chipwaits less than 1

- negative chipwaits currently brick the chip, since the user has no way to edit them, will open an issue.